### PR TITLE
Fixed error deserialization

### DIFF
--- a/src/ios/BackgroundDownload.m
+++ b/src/ios/BackgroundDownload.m
@@ -189,13 +189,12 @@ NSString *const FLTDownloadQueue = @"FLTDownloadQueue";
                 [fileManager createFileAtPath:targetURL.path contents:[fileManager contentsAtPath:[location path]] attributes:nil];
             } else {
                 NSData *fileData = [NSData dataWithContentsOfFile:[location path]];
-                NSError *error = nil;
-                NSDictionary *fileDict = [NSJSONSerialization JSONObjectWithData:fileData options:kNilOptions error:&error];
                 NSMutableDictionary *muteDict = [dict mutableCopy];
-                
-                if (fileDict[@"message"])
+                NSString *message = [[NSString alloc] initWithData:fileData encoding:NSUTF8StringEncoding];
+
+                if (message)
                 {
-                    muteDict[@"message"] = fileDict[@"message"];
+                    muteDict[@"message"] = message;
                     [array replaceObjectAtIndex:[array indexOfObject:dict] withObject:muteDict];
                     [[NSUserDefaults standardUserDefaults] setObject:array forKey:FLTDownloadQueue];
                     [[NSUserDefaults standardUserDefaults] synchronize];


### PR DESCRIPTION
Ref. Fliplet/fliplet-studio#3563

We had an issue with json format errors failing to persist in standardUserDefaults. To resolve that I just converted the whole error response to a string and saved that instead.
So now when a file request fails and returns a json response, it will not crash the app.